### PR TITLE
update jenkinsxio/builder-base to 0.0.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsxio/builder-base:0.0.13
+FROM jenkinsxio/builder-base:0.0.15
 
 ENV GOLANG_VERSION 1.9.2
 RUN wget https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz && \


### PR DESCRIPTION
[UpdateBot](https://github.com/fabric8io/updatebot) pushed docker dependency: `jenkinsxio/builder-base` to: `0.0.15`