### PR TITLE
Bump parent docker image and go to 1.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM jenkinsxio/builder-base:0.0.623
+FROM jenkinsxio/builder-base:0.1.77
 
 RUN yum -y groupinstall 'Development Tools'
 RUN curl -f -o /etc/yum.repos.d/vbatts-bazel-epel-7.repo  https://copr.fedorainfracloud.org/coprs/vbatts/bazel/repo/epel-7/vbatts-bazel-epel-7.repo && \
   yum install -y bazel
 
-ENV GOLANG_VERSION 1.11
+ENV GOLANG_VERSION 1.11.2
 RUN wget https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz && \
   tar -C /usr/local -xzf go$GOLANG_VERSION.linux-amd64.tar.gz && \
   rm go${GOLANG_VERSION}.linux-amd64.tar.gz


### PR DESCRIPTION
Several of us now have go 1.11.2 locally and it seems to cause problems with the modules hashes (https://github.com/golang/go/issues/27925). Would be great to align on the latest available.